### PR TITLE
Fix issue with encryption_key configuration in the documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Generate JWT secret and encryption key
 JWT_SECRET=$(openssl rand -base64 32)
-ENCRYPTION_KEY=$(openssl rand -base64 32)
+ENCRYPTION_KEY=$(openssl rand -hex 32)
 
 # Frontend
 VITE_API_URL=http://localhost:3001 # Backend API URL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Manual Docker deployment:
 ```bash
 # Generate keys
 openssl rand -base64 32  # JWT_SECRET
-openssl rand -base64 32  # ENCRYPTION_KEY
+openssl rand -hex 32  # ENCRYPTION_KEY
 
 # Create .env file with the generated keys
 docker-compose up -d

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,7 +16,7 @@ services:
       - DOCUMENTS_PATH=/data/documents
       - DB_PATH=/data/plumio.db
       - JWT_SECRET= openssl rand -base64 32 # example: sZS/0Ea3912P7DBOH9cYGw6fXXh5aRdhZ7bVRozPrvg=KFOENanjsrh821nMN59a
-      - ENCRYPTION_KEY= openssl rand -base64 32 # example: Am7PkJYuxEJYhu4fDdao37AX1XP0p/p2UuJ5Fxyh7Is=KFOENanjsrh821nMN59s
+      - ENCRYPTION_KEY= openssl rand -hex 32 # example: 9e23d572c66b7ae60d5b78de107b32b65a7b0a7f8a5821ccbf94e59f0d57c4ef
       - ALLOWED_ORIGINS=http://localhost:3000
       - ENABLE_ENCRYPTION=false
       # - SMTP_HOST=${SMTP_HOST}

--- a/website/docs/self-hosting.md
+++ b/website/docs/self-hosting.md
@@ -259,7 +259,7 @@ docker run --rm \
 
 ## Reverse Proxy (Optional)
 
-To use Plumio with a reverse proxy like Nginx or Caddy:
+To use Plumio with a reverse proxy like Nginx, Caddy or Traefik:
 
 ### Nginx
 
@@ -289,6 +289,25 @@ your-domain.com {
     reverse_proxy localhost:3000
     reverse_proxy /api/* localhost:3001
 }
+```
+
+### Traefik
+```yml
+services:
+  plumio:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.plumio.rule=Host(`plumio.yourdomain.com`)"
+      - "traefik.http.routers.plumio.entrypoints=websecure"
+      - "traefik.http.routers.plumio.tls.certresolver=letsencrypt"
+      - "traefik.http.services.plumio.loadbalancer.server.port=3000"
+    networks:
+      - traefik
+      - plumio-network
+
+networks:
+  traefik:
+    external: true
 ```
 
 ## Troubleshooting

--- a/website/docs/self-hosting.md
+++ b/website/docs/self-hosting.md
@@ -18,7 +18,7 @@ docker run -d \
   -p 3001:3001 \
   -v plumio-data:/data \
   -e JWT_SECRET="$(openssl rand -base64 32)" \
-  -e ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+  -e ENCRYPTION_KEY="$(openssl rand -hex 32)" \
   ghcr.io/albertasaftei/plumio:latest
 ```
 

--- a/website/docs/self-hosting.md
+++ b/website/docs/self-hosting.md
@@ -170,7 +170,7 @@ BACKEND_INTERNAL_PORT=3001
 DOCUMENTS_PATH=./documents
 DB_PATH=./data/plumio.db
 JWT_SECRET=$(openssl rand -base64 32)
-ENCRYPTION_KEY=$(openssl rand -base64 32)
+ENCRYPTION_KEY=$(openssl rand -hex 32)
 ENABLE_ENCRYPTION=true
 ```
 
@@ -292,6 +292,7 @@ your-domain.com {
 ```
 
 ### Traefik
+
 ```yml
 services:
   plumio:


### PR DESCRIPTION
Fixed a typo in the encryption_key and added traefik example to self-hosting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting instructions to generate `ENCRYPTION_KEY` using `openssl rand -hex 32`
  * Expanded reverse proxy documentation to include Traefik, with an added Traefik YAML example and Let’s Encrypt TLS setup
* **Chores**
  * Updated `CONTRIBUTING.md`, `.env.example`, and local `docker-compose` to use the new hex-based `ENCRYPTION_KEY` format
<!-- end of auto-generated comment: release notes by coderabbit.ai -->