### PR TITLE
fix(documents): preserve filename for no-extension files in getUniqueFilePath

### DIFF
--- a/backend/src/__tests__/paths.test.ts
+++ b/backend/src/__tests__/paths.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  getUniqueFilePath,
+  getOrgDocumentsPath,
+} from "../routes/documents/helpers/paths.js";
+
+const created: string[] = [];
+
+afterAll(() => {
+  for (const dir of created) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeExistingFile(organizationId: number, relPath: string) {
+  const full = path.join(getOrgDocumentsPath(organizationId), relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, "existing");
+  created.push(getOrgDocumentsPath(organizationId));
+}
+
+describe("getUniqueFilePath", () => {
+  it("preserves no-extension filenames when generating a unique name", async () => {
+    const orgId = 9001;
+    // A file named "README" (no extension) already exists.
+    writeExistingFile(orgId, "README");
+
+    const result = await getUniqueFilePath("README", orgId, true);
+
+    // The original filename must be retained: "README (1)", not " (1)".
+    expect(path.basename(result)).toBe("README (1)");
+  });
+
+  it("keeps the extension for files that have one", async () => {
+    const orgId = 9002;
+    writeExistingFile(orgId, "notes.md");
+
+    const result = await getUniqueFilePath("notes.md", orgId, true);
+
+    expect(path.basename(result)).toBe("notes (1).md");
+  });
+});

--- a/backend/src/routes/documents/helpers/paths.ts
+++ b/backend/src/routes/documents/helpers/paths.ts
@@ -58,7 +58,7 @@ export async function getUniqueFilePath(
   const dir = path.dirname(basePath);
   const filename = path.basename(basePath);
   const ext = path.extname(filename);
-  const nameWithoutExt = filename.slice(0, -ext.length);
+  const nameWithoutExt = ext ? filename.slice(0, -ext.length) : filename;
 
   // Try with incrementing counter until we find a unique name
   let counter = 1;


### PR DESCRIPTION
## Summary
`getUniqueFilePath` builds the base name with `filename.slice(0, -ext.length)`. For files without an extension (e.g. `README`, `.gitignore`), `path.extname` returns `""`, so `-ext.length` is `0` and the slice truncates the whole filename. When a new document collides with an existing one, the generated unique name becomes `" (1)"` instead of `"README (1)"`, silently dropping the user's document name.

## Root cause
`backend/src/routes/documents/helpers/paths.ts` — `filename.slice(0, -ext.length)` assumes a non-empty extension.

## Fix
Fall back to the full filename when `ext` is empty:
```ts
const ext = path.extname(filename);
const nameWithoutExt = ext ? filename.slice(0, -ext.length) : filename;
```

## Test plan
- Added `backend/src/__tests__/paths.test.ts` asserting `getUniqueFilePath("README", orgId, true)` yields a basename of `"README (1)"` (failed before the fix as `" (1)"`, passes after).
- Regression guard for extension files (`notes (1).md`) still passes.
- `tsc --noEmit` exits 0.

🤖 Opened on behalf of Diwak4r.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filename handling when creating unique document names, especially for files without extensions.
  - Unique filenames now keep the original base name correctly, such as `README (1)`.
  - Files with extensions continue to place the number before the extension, such as `notes (1).md`.
- **Tests**
  - Added coverage for unique file path generation to verify both extensionless and extension-based filename behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->