### PR TITLE
fix(documents): strip trailing dots left after whitespace in sanitizeFilename

### DIFF
--- a/backend/src/__tests__/paths.test.ts
+++ b/backend/src/__tests__/paths.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import {
   getUniqueFilePath,
   getOrgDocumentsPath,
+  sanitizeFilename,
 } from "../routes/documents/helpers/paths.js";
 
 const created: string[] = [];
@@ -40,5 +41,27 @@ describe("getUniqueFilePath", () => {
     const result = await getUniqueFilePath("notes.md", orgId, true);
 
     expect(path.basename(result)).toBe("notes (1).md");
+  });
+});
+
+describe("sanitizeFilename", () => {
+  it("strips a trailing dot even when whitespace follows it", () => {
+    // Regression: a trailing space kept the dot out of the /\.+$/ match,
+    // and the later trim() re-exposed it, leaving "Report." on disk —
+    // a name Windows rejects.
+    expect(sanitizeFilename("Report. ")).toBe("Report");
+    expect(sanitizeFilename("Q1 2026. ")).toBe("Q1 2026");
+    expect(sanitizeFilename("notes.. ")).toBe("notes");
+  });
+
+  it("still strips plain trailing dots and surrounding whitespace", () => {
+    expect(sanitizeFilename("Report.")).toBe("Report");
+    expect(sanitizeFilename("Report .")).toBe("Report");
+    expect(sanitizeFilename("  hi  ")).toBe("hi");
+  });
+
+  it("preserves internal dots and leading dots", () => {
+    expect(sanitizeFilename("a.b.")).toBe("a.b");
+    expect(sanitizeFilename(".hidden")).toBe(".hidden");
   });
 });

--- a/backend/src/routes/documents/helpers/paths.ts
+++ b/backend/src/routes/documents/helpers/paths.ts
@@ -27,8 +27,8 @@ export function sanitizeFilename(name: string): string {
     .replace(/[\/\\]/g, "-") // forward + back slashes → dash
     .replace(/[<>:"|?*]/g, "-") // Windows-reserved chars  → dash
     .replace(/[\x00-\x1f\x7f]/g, "") // control characters      → strip
-    .replace(/\.+$/, "") // trailing dots           → strip
-    .trim();
+    .trim() // surrounding whitespace  → strip
+    .replace(/[.\s]+$/, ""); // trailing dots / spaces  → strip
 }
 
 // Generate unique file path by appending (1), (2), etc. if file already exists


### PR DESCRIPTION
## Problem
`sanitizeFilename` (`backend/src/routes/documents/helpers/paths.ts`) strips trailing dots **before** trimming whitespace. When a name ends in a dot followed by a space — e.g. `"Report. "` — the `/\.+$/` match runs while the space is still at the end of the string, so nothing is stripped; the later `.trim()` then removes the space and re-exposes the dot, yielding `"Report."`.

Windows rejects filenames/directories ending in a dot, so the name recorded in SQLite (`"Report."`) diverges from the directory actually created on disk (`"Report"`) — the exact case the function's docblock says it guards against ("Windows rejects trailing dots/spaces").

Reproduction (current behavior):
```
sanitizeFilename("Report. ")  => "Report."   // trailing dot survives
sanitizeFilename("Q1 2026. ") => "Q1 2026."
```

## Fix
Trim first, then strip any trailing run of dots/spaces in one pass:
```ts
.trim()
.replace(/[.\s]+$/, "");
```
Internal dots (`"a.b."` → `"a.b"`) and leading dots (`".hidden"` → `".hidden"`) are preserved; plain trailing dots and surrounding whitespace still strip as before.

## How verified
- Added unit tests in `backend/src/__tests__/paths.test.ts` covering the regression and the preserved cases.
- `npx vitest run src/__tests__/paths.test.ts` → 5 passed.
- `npx tsc --noEmit` → clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename sanitization to consistently remove trailing dots and whitespace.
  * Preserved valid internal and leading dots in filenames.

* **Tests**
  * Added coverage for trailing dots, surrounding whitespace, and valid dot placement in filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->